### PR TITLE
connect-proxy: Routing and Error Handling improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM balena/open-balena-base:v5.0.0
 
-EXPOSE 80 443
+EXPOSE 80 443 3128
 
 RUN curl -s https://haproxy.debian.net/bernat.debian.org.gpg | apt-key add - >/dev/null \
 	&& echo deb http://haproxy.debian.net stretch-backports-1.8 main > /etc/apt/sources.list.d/haproxy.list \

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "open-balena-vpn",
-  "version": "8.2.0",
+  "version": "8.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1781,7 +1781,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
     },
     "@types/compression": {
       "version": "0.0.36",
-      "resolved": "https://registry.npmjs.org/@types/compression/-/compression-0.0.36.tgz",
+      "resolved": "http://registry.npmjs.org/@types/compression/-/compression-0.0.36.tgz",
       "integrity": "sha512-B66iZCIcD2eB2F8e8YDIVtCUKgfiseOR5YOIbmMN2tM57Wu55j1xSdxdSw78aVzsPmbZ6G+hINc+1xe1tt4NBg==",
       "requires": {
         "@types/express": "*"
@@ -76,7 +76,7 @@
     },
     "@types/events": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
       "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA=="
     },
     "@types/express": {
@@ -101,7 +101,7 @@
     },
     "@types/forever-monitor": {
       "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@types/forever-monitor/-/forever-monitor-1.7.3.tgz",
+      "resolved": "http://registry.npmjs.org/@types/forever-monitor/-/forever-monitor-1.7.3.tgz",
       "integrity": "sha512-3WdP/+biaXBDRAfqiX7URAIDnbi2iFvD3TjYZn63eyMFPhSe9Q+tusdATHetb9ldwtCz3diQ4Rd0vtfDhzDMXA==",
       "requires": {
         "@types/node": "*"
@@ -191,7 +191,7 @@
     },
     "@types/optimist": {
       "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/optimist/-/optimist-0.0.29.tgz",
+      "resolved": "http://registry.npmjs.org/@types/optimist/-/optimist-0.0.29.tgz",
       "integrity": "sha1-qIc1gLOoS2msHmhzI7Ffu+uQR5o=",
       "dev": true
     },
@@ -461,7 +461,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -712,17 +712,17 @@
       "dependencies": {
         "async": {
           "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-0.2.10.tgz",
           "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
         },
         "colors": {
           "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "resolved": "http://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
           "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w="
         },
         "winston": {
           "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.0.tgz",
+          "resolved": "http://registry.npmjs.org/winston/-/winston-0.8.0.tgz",
           "integrity": "sha1-YdCDD6aZcGISIGsKK1ymmpMENmg=",
           "requires": {
             "async": "0.2.x",
@@ -959,17 +959,17 @@
       "dependencies": {
         "async": {
           "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-0.2.10.tgz",
           "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
         },
         "colors": {
           "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "resolved": "http://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
           "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w="
         },
         "winston": {
           "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
+          "resolved": "http://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
           "integrity": "sha1-ZLar9M0Brcrv1QCTk7HY6L7BnbA=",
           "requires": {
             "async": "0.2.x",
@@ -1492,7 +1492,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
     },
     "ecc-jsbn": {
@@ -1518,7 +1518,7 @@
     },
     "enabled": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
       "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
       "requires": {
         "env-variable": "0.0.x"
@@ -1604,7 +1604,7 @@
     },
     "eventemitter2": {
       "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "resolved": "http://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
       "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas="
     },
     "execa": {
@@ -1749,7 +1749,7 @@
     },
     "fecha": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
+      "resolved": "http://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
       "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
     },
     "figures": {
@@ -1781,7 +1781,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",
@@ -2030,7 +2030,7 @@
     },
     "globby": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "dev": true,
       "requires": {
@@ -2161,7 +2161,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
         "depd": "~1.1.2",
@@ -2392,7 +2392,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
@@ -3217,7 +3217,7 @@
     },
     "load-json-file": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
@@ -3312,7 +3312,7 @@
     },
     "lru-cache": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
       "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
       "requires": {
         "pseudomap": "^1.0.1"
@@ -3369,7 +3369,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "mem": {
@@ -3456,7 +3456,7 @@
     },
     "minimist": {
       "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
       "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
     },
     "minipass": {
@@ -3507,7 +3507,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -3515,7 +3515,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
@@ -3541,7 +3541,7 @@
       "dependencies": {
         "commander": {
           "version": "2.15.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
           "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
           "dev": true
         },
@@ -3645,14 +3645,14 @@
       "dependencies": {
         "async": {
           "version": "0.2.9",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.9.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-0.2.9.tgz",
           "integrity": "sha1-32MGD789Myhqdqr21Vophtn/hhk="
         }
       }
     },
     "ncp": {
       "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
+      "resolved": "http://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
       "integrity": "sha1-q8xsvT7C7Spyn/bnwfqPAXhKhXQ="
     },
     "needle": {
@@ -3729,12 +3729,19 @@
       }
     },
     "node-tunnel": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/node-tunnel/-/node-tunnel-2.0.0.tgz",
-      "integrity": "sha512-pT/D5Wse7Okg6HavsnRcCcQFhcTsfbpM1no2ybzwnVudln2IvzHVHFCyxMCBoAqqR5SBFvNaawFDJ2ZcuMELlg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/node-tunnel/-/node-tunnel-2.1.0.tgz",
+      "integrity": "sha512-FQylF+afijD9HvWM6D1458sBe8yblDzIP0qHGcO9ywBiWd47LMi+7s00/8IiYInIRJ2BLZmYocelllFHyj4jGA==",
       "requires": {
         "basic-auth-parser": "0.0.2",
-        "bluebird": "^3.5.2"
+        "bluebird": "^3.5.3"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "3.5.3",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+          "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
+        }
       }
     },
     "nopt": {
@@ -3941,7 +3948,7 @@
     },
     "openvpn-client": {
       "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/openvpn-client/-/openvpn-client-0.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/openvpn-client/-/openvpn-client-0.0.2.tgz",
       "integrity": "sha1-nJzAZxsfcYglxpLj5KMm1QGYsvw=",
       "dev": true,
       "requires": {
@@ -3951,7 +3958,7 @@
       "dependencies": {
         "bluebird": {
           "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
           "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
           "dev": true
         },
@@ -3994,7 +4001,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "osenv": {
@@ -4082,7 +4089,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
@@ -4125,7 +4132,7 @@
     },
     "pause-stream": {
       "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "resolved": "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "requires": {
         "through": "~2.3"
@@ -4483,7 +4490,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -4605,7 +4612,7 @@
     },
     "require-npm4-to-publish": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/require-npm4-to-publish/-/require-npm4-to-publish-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/require-npm4-to-publish/-/require-npm4-to-publish-1.0.0.tgz",
       "integrity": "sha1-5Z7D5ikQFT3Fu90MpA20IrLE2ec=",
       "requires": {
         "in-publish": "^2.0.0",
@@ -5224,7 +5231,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
@@ -5238,7 +5245,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -5290,7 +5297,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "timed-out": {
@@ -5385,7 +5392,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -5587,7 +5594,7 @@
       "dependencies": {
         "async": {
           "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-0.2.10.tgz",
           "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
         }
       }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "middleware-handler": "~0.2.0",
     "morgan": "^1.9.1",
     "netmask": "^1.0.6",
-    "node-tunnel": "^2.0.0",
+    "node-tunnel": "^2.1.0",
     "pinejs-client-request": "^5.1.0",
     "pjson": "^1.0.9",
     "raven": "^2.6.4",

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -18,7 +18,7 @@
 import * as _Raven from 'raven';
 import { TypedError } from 'typed-error';
 
-import { logger, VERSION } from './utils';
+import { VERSION } from './utils';
 
 export const Raven = _Raven;
 
@@ -33,7 +33,6 @@ export const captureException = (
 	message?: string,
 	options?: _Raven.CaptureOptions,
 ): string => {
-	logger.error(message || '', err.message ? err.message : err, err.stack);
 	options = options || {};
 	if (message) {
 		options.extra = options.extra || {};
@@ -42,5 +41,9 @@ export const captureException = (
 	return Raven.captureException(err, options);
 };
 
+export class APIError extends TypedError {}
+export class BadRequestError extends TypedError {}
 export class HandledTunnelingError extends TypedError {}
+export class RemoteTunnellingError extends TypedError {}
 export class ServiceRegistrationError extends TypedError {}
+export class InvalidHostnameError extends TypedError {}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -31,10 +31,14 @@ export const balenaApi = new PinejsClientRequest(
 export const apiKey = process.env.VPN_SERVICE_API_KEY;
 export const VERSION = pkg.version;
 
-winston.add(
-	new winston.transports.Console({ format: winston.format.simple() }),
-);
+const consoleTransport = new winston.transports.Console({
+	format: winston.format.simple(),
+});
+export const logger = winston.createLogger({
+	transports: [consoleTransport],
+	exceptionHandlers: [consoleTransport],
+	exitOnError: false,
+});
 
 export { Netmask } from './netmask';
 export { request } from './request';
-export { winston as logger };

--- a/test/connect-proxy/device.ts
+++ b/test/connect-proxy/device.ts
@@ -26,7 +26,7 @@ const { expect } = chai;
 nock.disableNetConnect();
 
 const BALENA_API_HOST = process.env.BALENA_API_HOST!;
-const VPN_SERVICE_API_KEY = process.env.VPN_SERVICE_API_KEY!;
+const VPN_SERVICE_API_KEY = Buffer.from(process.env.VPN_SERVICE_API_KEY!);
 
 before(() => {
 	chai.use(chaiAsPromised);


### PR DESCRIPTION
### Route non local requests via the relevant instance

When a tunnel is requested for a device which is not directly connected,
the connect-proxy will lookup the appropriate instance in the api and
transparently establish the tunnel via that server.

Connects-to: #20
Change-type: minor
Signed-off-by: Will Boyce \<will@balena.io\>

### Improve error handling

Capture fewer errors in sentry, tidy up logging and handling of
expected errors.

Connects-to: #22 
Change-type: minor
Signed-off-by: Will Boyce \<will@balena.io\>

---

##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [X] Build output has been rebuilt and tested
- [ ] Introduces security considerations
- [ ] Tests are included
- [ ] Documentation is added or changed
- [X] Affects the development, build or deployment processes of the component

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---