### PR TITLE
perms: Add tunnel-any check when tunnelling ports

### DIFF
--- a/src/connect-proxy/device.ts
+++ b/src/connect-proxy/device.ts
@@ -72,7 +72,7 @@ export const canAccessDevice = (
 			id: device.id,
 			passthrough: { headers: authHeader(auth) },
 			body: {
-				action: `tunnel-${port}`,
+				action: { or: ['tunnel-any', `tunnel-${port}`] },
 			},
 			url: `device(${device.id})/canAccess`,
 		})


### PR DESCRIPTION
Add an additional check to the actions allowed when tunnelling
ports through the connect-proxy. This means that if the key used
is sufficiently privileged then any port can be tunnelled to a
device.

Change-type: patch
Signed-off-by: Rich Bayliss <rich@balena.io>

