### PR TITLE
haproxy: restore logs and fix timeout configs

### DIFF
--- a/config/confd/templates/haproxy.cfg.tmpl
+++ b/config/confd/templates/haproxy.cfg.tmpl
@@ -14,10 +14,12 @@ global
 	user haproxy
 	group haproxy
 	stats socket /var/run/haproxy.sock mode 600 level admin
-	log /dev/log local0 notice
+	log /dev/log local0
 
 defaults
-	log global
+	timeout connect 10s
+	timeout client 10s
+	timeout server 10s
 
 {{ if ne (getv "/balena/monitor/secret-token" "") "" -}}
 userlist metrics
@@ -44,30 +46,37 @@ frontend http-80
 
 backend proxy-master
 	mode http
+	log global
+	option httpchk GET /ping
+	http-check expect string OK
 	server proxy0 127.0.0.1:8888 check
 
 backend vpn-master
 	mode http
+	log global
+	option httpchk GET /ping
+	http-check expect string OK
 	server vpn0 127.0.0.1:8080 check
 {{- end }}
 
 frontend tcp-{{$vpnPort}}
 	mode tcp
 	bind ipv4@:{{$vpnPort}} {{$bindOpt}}
+	log global
 	option dontlognull
 	option logasap
 	option splice-auto
 	option tcp-smart-accept
-	option tcp-smart-connect
 	maxconn {{$maxconn}}
-	timeout connect 10s
 	timeout client {{$timeout}}s
-	timeout server {{$timeout}}s
 	# Routing <client-ip:port>@<frontend> to <backend>/<server>:<port> [Conns Queues Times]
 	log-format "Routing %ci:%cp@%ft to %b/%s:%bp [C:%bc/%sc Q:%bq/%sq T:%Tw/%Tc]"
 	default_backend vpn-workers
 
 backend vpn-workers
 	mode tcp
+	log global
 	balance leastconn
+	option tcp-smart-connect
+	timeout server {{$timeout}}s
 	server-template vpn 1-{{$servers}} 127.0.0.1:10000 check disabled

--- a/config/confd_env_backend/templates/haproxy.cfg.tmpl
+++ b/config/confd_env_backend/templates/haproxy.cfg.tmpl
@@ -14,10 +14,12 @@ global
 	user haproxy
 	group haproxy
 	stats socket /var/run/haproxy.sock mode 600 level admin
-	log /dev/log local0 notice
+	log /dev/log local0
 
 defaults
-	log global
+	timeout connect 10s
+	timeout client 10s
+	timeout server 10s
 
 {{ if ne (getenv "MONITOR_SECRET_TOKEN") "" -}}
 userlist metrics
@@ -44,30 +46,37 @@ frontend http-80
 
 backend proxy-master
 	mode http
+	log global
+	option httpchk GET /ping
+	http-check expect string OK
 	server proxy0 127.0.0.1:8888 check
 
 backend vpn-master
 	mode http
+	log global
+	option httpchk GET /ping
+	http-check expect string OK
 	server vpn0 127.0.0.1:8080 check
 {{- end }}
 
 frontend tcp-{{$vpnPort}}
 	mode tcp
 	bind ipv4@:{{$vpnPort}} {{$bindOpt}}
+	log global
 	option dontlognull
 	option logasap
 	option splice-auto
 	option tcp-smart-accept
-	option tcp-smart-connect
 	maxconn {{$maxconn}}
-	timeout connect 10s
 	timeout client {{$timeout}}s
-	timeout server {{$timeout}}s
 	# Routing <client-ip:port>@<frontend> to <backend>/<server>:<port> [Conns Queues Times]
 	log-format "Routing %ci:%cp@%ft to %b/%s:%bp [C:%bc/%sc Q:%bq/%sq T:%Tw/%Tc]"
 	default_backend vpn-workers
 
 backend vpn-workers
 	mode tcp
+	log global
 	balance leastconn
+	option tcp-smart-connect
+	timeout server {{$timeout}}s
 	server-template vpn 1-{{$servers}} 127.0.0.1:10000 check disabled


### PR DESCRIPTION
This restores external ip logging and deals with the warnings at startup

```
[WARNING] 202/134917 (79) : parsing [/etc/haproxy/haproxy.cfg:47] : 'tcp-smart-connect' ignored because frontend 'tcp-443' has no backend capability.
[WARNING] 202/134917 (79) : parsing [/etc/haproxy/haproxy.cfg:49] : 'timeout connect' will be ignored because frontend 'tcp-443' has no backend capability
[WARNING] 202/134917 (79) : parsing [/etc/haproxy/haproxy.cfg:51] : 'timeout server' will be ignored because frontend 'tcp-443' has no backend capability
[WARNING] 202/134917 (79) : config : missing timeouts for frontend 'http-80'.
| While not properly invalid, you will certainly encounter various problems
| with such a configuration. To fix this, please ensure that all following
| timeouts are set to a non-zero value: 'client', 'connect', 'server'.
[WARNING] 202/134917 (79) : config : missing timeouts for backend 'proxy-master'.
| While not properly invalid, you will certainly encounter various problems
| with such a configuration. To fix this, please ensure that all following
| timeouts are set to a non-zero value: 'client', 'connect', 'server'.
[WARNING] 202/134917 (79) : config : missing timeouts for backend 'vpn-master'.
| While not properly invalid, you will certainly encounter various problems
| with such a configuration. To fix this, please ensure that all following
```

Change-type: patch
Signed-off-by: Will Boyce \<will@balena.io\>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [X] Build output has been rebuilt and tested
- [ ] Introduces security considerations
- [ ] Tests are included
- [ ] Documentation is added or changed
- [ ] Affects the development, build or deployment processes of the component

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
