### PR TITLE
service: Ensure captureException does not throw

### DIFF
--- a/src/vpn-api/utils/service.ts
+++ b/src/vpn-api/utils/service.ts
@@ -29,9 +29,10 @@ class ServiceInstance {
 		const tags: { [key: string]: string } = {};
 		try {
 			tags.instance_id = this.getId();
-		} finally {
-			captureException(err, fingerprint, { tags });
-		}
+			// tslint:disable-next-line:no-empty
+		} catch {}
+
+		captureException(err, fingerprint, { tags });
 	}
 
 	public register(): Bluebird<this> {


### PR DESCRIPTION
The code in the captureException() method 'try's
to get an ID. If it fails, it 'finally' registers
the exception passed to it. Unfortunately, because
it doesn't 'catch', if the 'try' fails, then the
error from it bubbles up and the code calling
'captureException' does not finalise. This is
most prevalent should the API not currently be
running, as it won't register and the timed retry
to register will never get called.

This will also fix other calls made with it.

Change-type: patch
Signed-off-by: Heds Simons <heds@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Build output has been rebuilt and tested
- [ ] Introduces security considerations
- [ ] Tests are included
- [ ] Documentation is added or changed
- [ ] Affects the development, build or deployment processes of the component

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
