### PR TITLE
add prometheus node_exporter service in-image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,15 +11,43 @@ COPY src /usr/src/app/src
 RUN npm run build
 
 
+FROM golang:alpine AS gobuild
+
+RUN apk add make curl git && \
+	git clone https://github.com/prometheus/node_exporter && \
+	cd node_exporter && \
+	git checkout 5d3e2ce2ef927eeb44fc409d3cd1fbba884571f3 && \
+	make build && \
+	cp node_exporter /usr/bin/
+
+
 FROM base as main
 
-EXPOSE 80 443 3128
+EXPOSE 80 443 3128 9003
 
 RUN apt-get update -qq \
 	&& apt-get install -qy haproxy=1.8.* iptables --no-install-recommends \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/* /etc/apt/sources.list.d/*.list /etc/haproxy/* /etc/openvpn/* /etc/rsyslog.d/49-haproxy.conf \
 	&& ln -sf /usr/src/app/openvpn/scripts /etc/openvpn/scripts
+
+# MUSL-LIBC (for running 99%-static node_exporter binary built in gobuild stage)
+RUN wget http://www.musl-libc.org/releases/musl-1.1.10.tar.gz \
+	&& tar -xvf musl-1.1.10.tar.gz \
+	&& rm musl-1.1.10.tar.gz \
+	&& cd musl-1.1.10 \
+	&& ./configure \
+	&& make \
+	&& make install \
+	&& cd .. \
+	&& rm -rf musl-1.1.10
+
+# install nginx for auth-protecting node exporter metrics path
+RUN apt-get update \
+	&& apt-get -y -f install nginx \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& mkdir -p /etc/nginx
+COPY config/nginx/ /etc/nginx/
 
 ENV LIBNSS_OPENVPN_VERSION 22feb11322182f6fd79f85cd014b65b6c40b7b47
 RUN tmp="$(mktemp -d)" set -x \
@@ -35,9 +63,15 @@ COPY package.json package-lock.json /usr/src/app/
 RUN npm ci --unsafe-perm --production && npm cache clean --force 2>/dev/null
 
 COPY --from=builder /usr/src/app/build /usr/src/app/build
+COPY --from=gobuild /usr/bin/node_exporter /bin/
 COPY bin /usr/src/app/bin
 COPY config /usr/src/app/config
 COPY openvpn /usr/src/app/openvpn
 
 COPY config/services /etc/systemd/system
-RUN systemctl enable open-balena-vpn-api.service open-balena-connect-proxy.service
+RUN systemctl enable \
+	open-balena-vpn-api.service \
+	open-balena-connect-proxy.service \
+	create-htpasswd \
+	nginx \
+	node-exporter

--- a/config/confd/conf.d/create-htpasswd.sh.toml
+++ b/config/confd/conf.d/create-htpasswd.sh.toml
@@ -1,0 +1,7 @@
+[template]
+src = "create-htpasswd.sh.tmpl"
+dest = "/usr/share/create-htpasswd.sh"
+mode = "0744"
+keys = [
+	"/balena/monitor/secret-token",
+]

--- a/config/confd/templates/create-htpasswd.sh.tmpl
+++ b/config/confd/templates/create-htpasswd.sh.tmpl
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+token={{getv "/balena/monitor/secret-token"}}
+
+encrypted=$(echo $token | openssl passwd -apr1 -stdin)
+
+echo "monitor:${encrypted}" > /etc/nginx/.htpasswd

--- a/config/confd_env_backend/conf.d/create-htpasswd.sh.toml
+++ b/config/confd_env_backend/conf.d/create-htpasswd.sh.toml
@@ -1,0 +1,7 @@
+[template]
+src = "create-htpasswd.sh.tmpl"
+dest = "/usr/share/create-htpasswd.sh"
+mode = "0744"
+keys = [
+	"BALENA_MONITOR_SECRET_TOKEN"
+]

--- a/config/confd_env_backend/templates/create-htpasswd.sh.tmpl
+++ b/config/confd_env_backend/templates/create-htpasswd.sh.tmpl
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+token={{getenv "BALENA_MONITOR_SECRET_TOKEN"}}
+
+encrypted=$(echo $token | openssl passwd -apr1 -stdin)
+
+echo "monitor:${encrypted}" > /etc/nginx/.htpasswd

--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -1,0 +1,19 @@
+http {
+
+    server {
+
+        listen 9003;
+
+		# error_log stderr debug;
+
+		location /metrics {
+			auth_basic           "metrics";
+			auth_basic_user_file /etc/nginx/.htpasswd; 
+			proxy_pass http://127.0.0.1:9000/metrics;
+		}
+
+	}
+
+}
+
+events {}

--- a/config/services/create-htpasswd.service
+++ b/config/services/create-htpasswd.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=create /usr/share/prometheus/.htpasswd
+Requires=local-fs.target confd.service
+After=confd.service
+Before=nginx.service
+
+[Service]
+StandardOutput=journal+console
+StandardError=journal+console
+User=root
+Group=root
+Type=oneshot
+
+ExecStart=/usr/share/create-htpasswd.sh
+
+SyslogIdentifier=create-htpasswd
+
+[Install]
+WantedBy=multi-user.target
+RequiredBy=nginx.service

--- a/config/services/nginx.service
+++ b/config/services/nginx.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=The NGINX HTTP and reverse proxy server
+After=syslog.target network.target remote-fs.target nss-lookup.target
+
+[Service]
+Type=forking
+PIDFile=/run/nginx.pid
+ExecStartPre=/usr/sbin/nginx -t
+ExecReload=/usr/sbin/nginx -s reload
+ExecStop=/bin/kill -s QUIT $MAINPID
+PrivateTmp=true
+
+ExecStart=/usr/sbin/nginx
+
+[Install]
+WantedBy=basic.target

--- a/config/services/node-exporter.service
+++ b/config/services/node-exporter.service
@@ -1,0 +1,51 @@
+[Unit]
+Description=Prometheus Node Exporter
+Requires=network-online.target nginx.service
+After=network-online.target nginx.service
+
+[Service]
+StandardOutput=journal+console
+StandardError=journal+console
+Type=simple
+
+ExecStart=/bin/node_exporter \
+    --web.listen-address :9000 \
+    --web.telemetry-path /metrics \
+    --no-collector.arp \
+    --no-collector.bcache \
+    --no-collector.bonding \
+    --no-collector.conntrack \
+    --no-collector.cpu \
+    --no-collector.cpufreq \
+    --no-collector.diskstats \
+    --no-collector.edac \
+    --no-collector.entropy \
+    --no-collector.filefd \
+    --no-collector.filesystem \
+    --no-collector.hwmon \
+    --no-collector.infiniband \
+    --no-collector.ipvs \
+    --no-collector.loadavg \
+    --no-collector.mdadm \
+    --no-collector.meminfo \
+    --no-collector.netclass \
+    --no-collector.netdev \
+    --no-collector.nfs \
+    --no-collector.nfsd \
+    --no-collector.pressure \
+    --no-collector.schedstat \
+    --no-collector.sockstat \
+    --no-collector.stat \
+    --no-collector.textfile \
+    --no-collector.time \
+    --no-collector.timex \
+    --no-collector.uname \
+    --no-collector.vmstat \
+    --no-collector.xfs \
+    --no-collector.zfs
+
+Restart=always
+SyslogIdentifier=node-exporter
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
re: https://www.flowdock.com/app/rulemotion/resin-tech/threads/3c8dMtg98N1c-PBsR6xJgnpeR3m

quick test if you don't want to run it through BoB:

```
$ docker build -t open-balena-vpn:local .

$ docker run -d --rm -v /sys/fs/cgroup:/sys/fs/cgroup:ro,rslave --security-opt seccomp=unconfined -e 'CONFD_BACKEND=ENV' -e 'BALENA_MONITOR_SECRET_TOKEN=foobar' -it open-balena-vpn:local

$ CONTAINER_IP=$(docker inspect $(docker ps | grep "open-balena-vpn:local" | awk '{print $1}') -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')

$ curl -v --user monitor:foobar ${CONTAINER_IP}:9003/metrics
```

Change-type: minor
Signed-off-by: Nick Payne <nickp@balena.io>