### PR TITLE
Avoid unintentionally keeping large strings in memory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1640,6 +1640,11 @@
         "is-buffer": "~2.0.3"
       }
     },
+    "flatstr": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
+      "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
+    },
     "fn.name": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "event-stream": "^4.0.1",
     "eventemitter3": "^4.0.4",
     "express": "^4.17.1",
+    "flatstr": "^1.0.12",
     "lodash": "^4.17.20",
     "memoizee": "^0.4.14",
     "middleware-handler": "^0.2.0",

--- a/src/vpn-worker.ts
+++ b/src/vpn-worker.ts
@@ -21,6 +21,7 @@ import { getLogger } from './utils';
 
 import { HAProxy, Metrics, Netmask, VpnManager } from './utils';
 import { VpnClientBytecountData } from './utils/openvpn';
+import flatstr = require('flatstr');
 
 const BALENA_VPN_GATEWAY = process.env.BALENA_VPN_GATEWAY;
 const VPN_BASE_SUBNET = process.env.VPN_BASE_SUBNET!;
@@ -133,7 +134,9 @@ const worker = async (instanceId: number, serviceId: number) => {
 			`connection established with client_id=${clientId} uuid=${data.username}`,
 		);
 		clientCache[clientId] = {
-			uuid: data.common_name,
+			// We need to flatten the uuid because otherwise it's a sliced string and keeps the
+			// original, rather large, string in memory forever
+			uuid: flatstr(data.common_name),
 			bytes_received: 0,
 			bytes_sent: 0,
 			ts: process.hrtime()[0],

--- a/typings/flatstr.d.ts
+++ b/typings/flatstr.d.ts
@@ -1,0 +1,21 @@
+/*
+	Copyright (C) 2020 Balena Ltd.
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published
+	by the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+declare module 'flatstr' {
+	function flatstr(s: string): string;
+	export = flatstr;
+}


### PR DESCRIPTION
`data.common_name` is constructed from openvpn logs via substrings/slices in such a way that a reference to the original large string is kept around, that string can be anywhere from 1-20kb from the looks of it and when multiplied per each uuid that ever connects it can end up leaking significant memory. `flatstr` purports to handle flattening these strings in a performant method and should be updated as new methods are necessary/etc so makes sense as the first thing to try, but there are alternatives, eg `Buffer.from(s).toString()` should apparently work as well