### PR TITLE
Add data-ciphers-fallback to allow older openvpn clients to connect

### DIFF
--- a/config/confd/templates/server.conf.tmpl
+++ b/config/confd/templates/server.conf.tmpl
@@ -27,6 +27,10 @@ tls-server
 # accept TLS v1.2 minimum
 tls-version-min 1.2
 
+data-ciphers AES-128-GCM:AES-192-GCM:AES-256-GCM:AES-128-CBC:AES-192-CBC:AES-256-CBC
+# allow older openvpn installations to connect
+data-ciphers-fallback BF-CBC
+
 group nogroup
 user nobody
 


### PR DESCRIPTION
Change-type: patch

<!-- You can remove tags that do not apply. -->
Change-type: major|minor|patch <!-- The change type of this PR -->
Connects-to: # <!-- waffle convention to track a PR's status through its connected, open issue -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Build output has been rebuilt and tested
- [ ] Introduces security considerations
- [ ] Tests are included
- [ ] Documentation is added or changed
- [ ] Affects the development, build or deployment processes of the component

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
