### PR TITLE
Raise soft open files limit for HAProxy

### DIFF
--- a/config/services/haproxy.service.d/haproxy.conf
+++ b/config/services/haproxy.service.d/haproxy.conf
@@ -17,6 +17,9 @@
 Requires=confd.service
 After=confd.service
 
+[Service]
+LimitNOFILE=1048576
+
 [Install]
 WantedBy=
 WantedBy=basic.target


### PR DESCRIPTION
HAProxy is running out of FDs in production:

```
# for pid in $(pgrep haproxy); do cat /proc/$pid/limits | grep -E '^Limit|open files'; done
Limit                     Soft Limit           Hard Limit           Units     
Max open files            37563                1048576              files     

Limit                     Soft Limit           Hard Limit           Units     
Max open files            37563                1048576              files  
```

The container sets hard limit 1048576, but systemd is defaulting to soft limit 37563.

HAProxy logs are currently full of events like:

```
Nov 13 17:28:45 open-balena-vpn-799b5b7d66-27nc9 haproxy[110]: Proxy tcp-443 reached process FD limit (maxsock=37563). Please check 'ulimit-n' and restart.
Nov 13 17:28:45 open-balena-vpn-799b5b7d66-27nc9 haproxy[110]: Proxy tcp-443 reached process FD limit (maxsock=37563). Please check 'ulimit-n' and restart.
Nov 13 17:28:45 open-balena-vpn-799b5b7d66-27nc9 haproxy[110]: Proxy tcp-443 reached process FD limit (maxsock=37563). Please check 'ulimit-n' and restart.
...
```