### PR TITLE
Ignore the worker id when deciding if we have a state change to report

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -51,8 +51,10 @@ export const apiFactory = (serviceId: number) => {
 
 	const logger = getLogger('vpn', serviceId);
 
-	const logStateUpdate = (state: clients.DeviceState) => {
-		let stateMsg = `uuid=${state.common_name} worker_id=${state.worker_id} connected=${state.connected}`;
+	const logStateUpdate = (
+		state: Awaited<clients.DeviceStateTracker['promise']>,
+	) => {
+		let stateMsg = `uuid=${state.common_name} worker_id=${state.workerId} connected=${state.connected}`;
 		if (state.virtual_address != null) {
 			stateMsg = `${stateMsg} virtual_address=${state.virtual_address}`;
 		}


### PR DESCRIPTION
We never send the worker id to the api so even if it changes there's
still nothing to report and so we can potentially avoid unnecessary
state reports

Change-type: patch

<!-- You can remove tags that do not apply. -->
Change-type: major|minor|patch <!-- The change type of this PR -->
Connects-to: # <!-- waffle convention to track a PR's status through its connected, open issue -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Build output has been rebuilt and tested
- [ ] Introduces security considerations
- [ ] Tests are included
- [ ] Documentation is added or changed
- [ ] Affects the development, build or deployment processes of the component

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
