### PR TITLE
Add a 1s delay between batch reports to increase the chance of batching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "mocha": "^9.2.1",
         "nock": "^13.2.4",
         "openvpn-client": "0.0.2",
-        "ts-node": "^10.5.0",
+        "ts-node": "^10.6.0",
         "typescript": "^4.6.2"
       },
       "engines": {
@@ -4867,9 +4867,9 @@
       "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "node_modules/ts-node": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.5.0.tgz",
-      "integrity": "sha512-6kEJKwVxAJ35W4akuiysfKwKmjkbYxwQMTBaAxo9KKAx/Yd26mPUyhGz3ji+EsJoAgrLqVsYHNuuYwQe22lbtw==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.6.0.tgz",
+      "integrity": "sha512-CJen6+dfOXolxudBQXnVjRVvYTmTWbyz7cn+xq2XTsvnaXbHqr4gXSCNbS2Jj8yTZMuGwUoBESLaOkLascVVvg==",
       "dev": true,
       "dependencies": {
         "@cspotcode/source-map-support": "0.7.0",
@@ -9251,9 +9251,9 @@
       "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "ts-node": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.5.0.tgz",
-      "integrity": "sha512-6kEJKwVxAJ35W4akuiysfKwKmjkbYxwQMTBaAxo9KKAx/Yd26mPUyhGz3ji+EsJoAgrLqVsYHNuuYwQe22lbtw==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.6.0.tgz",
+      "integrity": "sha512-CJen6+dfOXolxudBQXnVjRVvYTmTWbyz7cn+xq2XTsvnaXbHqr4gXSCNbS2Jj8yTZMuGwUoBESLaOkLascVVvg==",
       "dev": true,
       "requires": {
         "@cspotcode/source-map-support": "0.7.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "mocha": "^9.2.1",
     "nock": "^13.2.4",
     "openvpn-client": "0.0.2",
-    "ts-node": "^10.5.0",
+    "ts-node": "^10.6.0",
     "typescript": "^4.6.2"
   },
   "engines": {

--- a/src/utils/clients.ts
+++ b/src/utils/clients.ts
@@ -26,6 +26,7 @@
 // the API has a special endpoint that first sets all clients as offline.
 
 import { IncomingMessage } from 'http';
+import { setTimeout } from 'timers/promises';
 import { Logger } from 'winston';
 
 import { apiKey, captureException } from './index';
@@ -119,6 +120,7 @@ export const setConnected = (() => {
 				reportUpdates(serviceId, connects, true, logger),
 			]);
 		} finally {
+			await setTimeout(1000);
 			currentlyReporting = false;
 			// Check if any pending updates have come in whilst we were reporting
 			updateLoop(serviceId, logger);


### PR DESCRIPTION
This will make it more likely for reports to be batched and increase
the batch size, reducing the number of requests necessary without
adding a significant delay for reporting, this will also help throttle
in the case of report failures

Change-type: patch

<!-- You can remove tags that do not apply. -->
Change-type: major|minor|patch <!-- The change type of this PR -->
Connects-to: # <!-- waffle convention to track a PR's status through its connected, open issue -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Build output has been rebuilt and tested
- [ ] Introduces security considerations
- [ ] Tests are included
- [ ] Documentation is added or changed
- [ ] Affects the development, build or deployment processes of the component

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
