### PR TITLE
Allow the client-connect/disconnect script to fail if necessary

### DIFF
--- a/openvpn/scripts/client-connect.sh
+++ b/openvpn/scripts/client-connect.sh
@@ -21,7 +21,7 @@ set -o errexit
 VPN_INSTANCE_ID=$1
 VPN_API_PORT=$2
 
-curl -s -X POST -H 'Content-type: application/json' -d @- "http://127.0.0.1:${VPN_API_PORT}/api/v2/${VPN_INSTANCE_ID}/clients" >/dev/null <<-EOF || true
+curl -s -X POST -H 'Content-type: application/json' -d @- "http://127.0.0.1:${VPN_API_PORT}/api/v2/${VPN_INSTANCE_ID}/clients" >/dev/null <<-EOF
 {
 	"common_name": "$common_name"
 }

--- a/openvpn/scripts/client-disconnect.sh
+++ b/openvpn/scripts/client-disconnect.sh
@@ -18,7 +18,7 @@
 VPN_INSTANCE_ID=$1
 VPN_API_PORT=$2
 
-curl -s -X DELETE -H 'Content-type: application/json' -d @- "http://127.0.0.1:${VPN_API_PORT}/api/v2/${VPN_INSTANCE_ID}/clients" >/dev/null <<-EOF || true
+curl -s -X DELETE -H 'Content-type: application/json' -d @- "http://127.0.0.1:${VPN_API_PORT}/api/v2/${VPN_INSTANCE_ID}/clients" >/dev/null <<-EOF
 {
 	"common_name": "$common_name",
 	"bytes_received": $bytes_received,


### PR DESCRIPTION
These curl commands should never fail as they're talking to the local
nodejs instance, but if for some reason they do it's better to reject
the client than pretend things are ok because they're really not

Change-type: patch

<!-- You can remove tags that do not apply. -->
Change-type: major|minor|patch <!-- The change type of this PR -->
Connects-to: # <!-- waffle convention to track a PR's status through its connected, open issue -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Build output has been rebuilt and tested
- [ ] Introduces security considerations
- [ ] Tests are included
- [ ] Documentation is added or changed
- [ ] Affects the development, build or deployment processes of the component

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
