### PR TITLE
Fixes check for uuid to serviceID assignement

### DIFF
--- a/src/proxy-worker.ts
+++ b/src/proxy-worker.ts
@@ -91,7 +91,7 @@ class Tunnel extends nodeTunnel.Tunnel {
 				return socket;
 			} else {
 				const vpnHost = await device.getDeviceVpnHost(uuid, auth);
-				if (vpnHost.id === this.serviceId) {
+				if (vpnHost.id !== this.serviceId) {
 					client.end(HTTP_500);
 					throw new errors.HandledTunnelingError(
 						'device is not available on registered service instance',


### PR DESCRIPTION
As the vpn registers a serviceID with UUIDs in the api
checking back if the serviceID is registered with the UUID should not throw an error on equality.

Change-type: patch
