### PR TITLE
Shard haproxy's VPN connection listener to the number of threads

### DIFF
--- a/config/confd/templates/haproxy.cfg.tmpl
+++ b/config/confd/templates/haproxy.cfg.tmpl
@@ -66,7 +66,7 @@ backend vpn-master
 
 frontend tcp-{{$vpnPort}}
 	mode tcp
-	bind ipv4@:{{$vpnPort}} {{$bindOpt}}
+	bind ipv4@:{{$vpnPort}} shards by-thread {{$bindOpt}}
 	log global
 	option dontlognull
 	option logasap


### PR DESCRIPTION
This will create 1 listening socket per thread and avoids lock
contention for the threads, at the cost of increasing the CPU usage
per thread slightly

Change-type: patch

<!-- You can remove tags that do not apply. -->
Change-type: major|minor|patch <!-- The change type of this PR -->
Connects-to: # <!-- waffle convention to track a PR's status through its connected, open issue -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Build output has been rebuilt and tested
- [ ] Introduces security considerations
- [ ] Tests are included
- [ ] Documentation is added or changed
- [ ] Affects the development, build or deployment processes of the component

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
