### PR TITLE
Always send a connect event to the API if the connected worker changes

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -68,7 +68,7 @@ const checkDeviceAuth = memoize(
 export const apiFactory = (serviceId: number) => {
 	const api = express.Router();
 
-	const workerMap: _.Dictionary<string> = {};
+	const workerMap: _.Dictionary<number> = {};
 
 	const logger = getLogger('vpn', serviceId);
 
@@ -84,14 +84,14 @@ export const apiFactory = (serviceId: number) => {
 		metrics.inc(Metrics.OnlineDevices);
 		metrics.inc(Metrics.TotalDevices);
 
-		const workerId = req.params.worker;
+		const workerId = parseInt(req.params.worker, 10);
 		const uuid = req.body.common_name;
-		if (workerMap[uuid] != null && workerMap[uuid] !== req.params.worker) {
+		if (workerMap[uuid] != null && workerMap[uuid] !== workerId) {
 			metrics.dec(Metrics.OnlineDevices);
 		}
 
 		workerMap[uuid] = workerId;
-		clients.setConnected(uuid, serviceId, true, logger);
+		clients.setConnected(uuid, serviceId, workerId, true, logger);
 	});
 
 	api.post('/api/v1/auth/', fromLocalHost, async function (req, res) {
@@ -137,7 +137,7 @@ export const apiFactory = (serviceId: number) => {
 			metrics.histogram(Metrics.SessionDuration, req.body.time_duration);
 		}
 
-		const workerId = req.params.worker;
+		const workerId = parseInt(req.params.worker, 10);
 		const uuid = req.body.common_name;
 
 		if (workerMap[uuid] !== workerId) {
@@ -157,7 +157,7 @@ export const apiFactory = (serviceId: number) => {
 
 		metrics.dec(Metrics.OnlineDevices);
 
-		clients.setConnected(uuid, serviceId, false, logger);
+		clients.setConnected(uuid, serviceId, workerId, false, logger);
 	});
 
 	return api;

--- a/src/vpn-worker.ts
+++ b/src/vpn-worker.ts
@@ -30,7 +30,7 @@ import {
 	VPN_VERBOSE_LOGS,
 } from './utils/config';
 
-import { clients, getLogger } from './utils';
+import { getLogger } from './utils';
 
 import { HAProxy, Metrics, Netmask, VpnManager } from './utils';
 import { VpnClientBytecountData } from './utils/openvpn';
@@ -127,8 +127,6 @@ const worker = async (instanceId: number, serviceId: number) => {
 					const cn = client.uuid;
 					try {
 						logger.info(`disconnecting ${cn}`);
-						// update device state
-						clients.setConnected(cn, serviceId, false, logger);
 						// disconnect client from VPN
 						await vpn.killClient(cn);
 					} catch (err) {


### PR DESCRIPTION
This solves an issue that could happen where the device reconnects in
rapid succession and connects to another VPN container and then back to
the current one without yet having been recognized as disconnected from
the current VPN container and as such we would not send a connect event
for the reconnection. This would result in the device appearing to be
offline for the API (because it disconnected from the other instance)
whilst actually still being connected, just to this instance

Change-type: patch

<!-- You can remove tags that do not apply. -->
Change-type: major|minor|patch <!-- The change type of this PR -->
Connects-to: # <!-- waffle convention to track a PR's status through its connected, open issue -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Build output has been rebuilt and tested
- [ ] Introduces security considerations
- [ ] Tests are included
- [ ] Documentation is added or changed
- [ ] Affects the development, build or deployment processes of the component

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
