### PR TITLE
Switch to conditionally calling husky install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,7 @@ RUN PROCESS_EXPORTER_TGZ="/tmp/process_exporter.tar.gz" set -x \
     && rm "${PROCESS_EXPORTER_TGZ}"
 
 COPY package.json package-lock.json /usr/src/app/
-RUN HUSKY=0 npm ci --production && npm cache clean --force
+RUN npm ci --production && npm cache clean --force
 
 COPY --from=auth-plugin /usr/src/app/auth-script-openvpn/openvpn-plugin-auth-script.so /etc/openvpn/plugins/
 COPY --from=builder /usr/src/app/build /usr/src/app/build

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "pretest-unit": "npm run lint",
     "test-unit": "mocha test/index.ts",
     "test": "docker build -t test-balena-vpn . && IMAGE_NAME=test-balena-vpn ./automation/test.sh",
-    "prepare": "[ \"$HUSKY\" = 0 ] || husky install"
+    "prepare": "node -e \"try { require('husky').install() } catch (e) {if (e.code !== 'MODULE_NOT_FOUND') throw e}\""
   },
   "dependencies": {
     "@balena/node-metrics-gatherer": "^6.0.3",


### PR DESCRIPTION
This avoids errors when trying to install with `npm ci --production`
where husky won't exist whilst also working on windows

Change-type: patch

<!-- You can remove tags that do not apply. -->
Change-type: major|minor|patch <!-- The change type of this PR -->
Connects-to: # <!-- waffle convention to track a PR's status through its connected, open issue -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Build output has been rebuilt and tested
- [ ] Introduces security considerations
- [ ] Tests are included
- [ ] Documentation is added or changed
- [ ] Affects the development, build or deployment processes of the component

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
