### PR TITLE
Set desired es-version for downstream modules that support it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@balena/env-parsing": "^1.1.0",
+        "@balena/es-version": "^1.0.1",
         "@balena/node-metrics-gatherer": "^6.0.3",
         "@sentry/node": "^7.12.0",
         "bluebird": "^3.7.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@balena/env-parsing": "^1.1.0",
+    "@balena/es-version": "^1.0.1",
     "@balena/node-metrics-gatherer": "^6.0.3",
     "@sentry/node": "^7.12.0",
     "bluebird": "^3.7.2",

--- a/src/app.ts
+++ b/src/app.ts
@@ -15,6 +15,10 @@
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+import { set } from '@balena/es-version';
+// Set the desired es version for downstream modules that support it, before we import any
+set('es2021');
+
 import { metrics } from '@balena/node-metrics-gatherer';
 import * as cluster from 'cluster';
 import * as express from 'express';


### PR DESCRIPTION
Notably this will cause pinejs-client to use a version with native async/await and hence allow for async stack traces

Change-type: patch