### PR TITLE
Stop automatic int parsing of openvpn events to avoid false positives

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -35,7 +35,7 @@ import {
 	VPN_AUTH_CACHE_TIMEOUT,
 } from './utils/config';
 import { Sentry } from './utils/errors';
-import { hasDurationData, isTrusted } from './utils/openvpn';
+import { hasDurationData, hasCommonName } from './utils/openvpn';
 
 // Private endpoints should use the `fromLocalHost` middleware.
 const fromLocalHost: express.RequestHandler = (req, res, next) => {
@@ -75,7 +75,7 @@ export const apiFactory = (serviceId: number) => {
 	api.use(express.json());
 
 	api.post('/api/v2/:worker/clients/', fromLocalHost, (req, res) => {
-		if (!isTrusted(req.body)) {
+		if (!hasCommonName(req.body)) {
 			return res.status(400).end();
 		}
 		// Immediately respond to minimize time in the client-connect script
@@ -135,7 +135,7 @@ export const apiFactory = (serviceId: number) => {
 	});
 
 	api.delete('/api/v2/:worker/clients/', fromLocalHost, (req, res) => {
-		if (!isTrusted(req.body)) {
+		if (!hasCommonName(req.body)) {
 			return res.status(400).end();
 		}
 


### PR DESCRIPTION
This avoids the case where a uuid could be a valid int and be parsed as a false positive and cause issues. It also avoids the overhead of parsing ints when their parsed form may never be needed.

Change-type: patch