### PR TITLE
Explicitly/consistently use 127.0.0.1 as the openvpn management host

### DIFF
--- a/src/utils/openvpn.ts
+++ b/src/utils/openvpn.ts
@@ -124,6 +124,7 @@ export class VpnManager extends EventEmitter {
 	private readonly connector = new Telnet();
 	private buf: string = '';
 	private readonly pidFile: string;
+	private readonly mgtHost = '127.0.0.1';
 
 	constructor(
 		private instanceId: number,
@@ -171,7 +172,7 @@ export class VpnManager extends EventEmitter {
 			'--port',
 			`${this.vpnPort}`,
 			'--management',
-			'127.0.0.1',
+			this.mgtHost,
 			`${this.mgtPort}`,
 			'--management-hold',
 			'--ifconfig',
@@ -346,7 +347,7 @@ export class VpnManager extends EventEmitter {
 				socket.on('ready', readyHandler);
 				socket.on('error', errorHandler);
 				socket.on('timeout', errorHandler);
-				socket.connect(this.mgtPort);
+				socket.connect(this.mgtPort, this.mgtHost);
 			}).timeout(STARTUP_TIMEOUT - (Date.now() - since));
 		} catch (err) {
 			if (err instanceof Bluebird.TimeoutError) {
@@ -370,7 +371,7 @@ export class VpnManager extends EventEmitter {
 
 	public async connect() {
 		await this.connector.connect({
-			host: '127.0.0.1',
+			host: this.mgtHost,
 			port: this.mgtPort,
 			shellPrompt: '',
 			negotiationMandatory: true,


### PR DESCRIPTION
This fixes issues if `socket.connect` tries to connect using ipv6 localhost rather than ipv4

Change-type: patch

<!-- You can remove tags that do not apply. -->
Change-type: major|minor|patch <!-- The change type of this PR -->
Connects-to: # <!-- waffle convention to track a PR's status through its connected, open issue -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Build output has been rebuilt and tested
- [ ] Introduces security considerations
- [ ] Tests are included
- [ ] Documentation is added or changed
- [ ] Affects the development, build or deployment processes of the component

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
