### PR TITLE
Push ping-exit directive to clients rather than ping-restart

### DIFF
--- a/config/confd/templates/server.conf.tmpl
+++ b/config/confd/templates/server.conf.tmpl
@@ -11,7 +11,12 @@ persist-tun
 
 proto tcp4-server
 compress lzo
-keepalive {{ getenv "VPN_KEEPALIVE_FREQUENCY" "10" }} {{ getenv "VPN_KEEPALIVE_TIMEOUT" "60" }}
+
+# Tell clients to exit on keepalive timeouts
+ping {{ getenv "VPN_KEEPALIVE_FREQUENCY" "10" }}                    # interval
+ping-exit {{ (atoi (getenv "VPN_KEEPALIVE_TIMEOUT" "60")) mul 2 }}  # timeout*2
+push "ping {{ getenv "VPN_KEEPALIVE_FREQUENCY" "10" }}"             # interval
+push "ping-exit {{ getenv "VPN_KEEPALIVE_TIMEOUT" "60" }}"          # timeout
 
 # Increase the max clients from the default of 1024 (hard limit applied by subnet/pool config)
 max-clients 32768


### PR DESCRIPTION
balenaOS devices drop privileges after starting OpenVPN so the SIGUSR1 is unable to recreate the socket.

Instead, have the server push the ping-exit directive as per the OpenVPN docs. This way balenaOS will stop and restart the service.

Change-type: minor
Signed-off-by: Kyle Harding <kyle@balena.io>
See: https://github.com/balena-os/meta-balena/issues/1779

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Build output has been rebuilt and tested
- [ ] Introduces security considerations
- [x] Tests are included
- [ ] Documentation is added or changed
- [ ] Affects the development, build or deployment processes of the component

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
