### PR TITLE
Add a configurable minimum client drain rate when terminating

### DIFF
--- a/config/confd/templates/env.tmpl
+++ b/config/confd/templates/env.tmpl
@@ -40,6 +40,7 @@ DEFAULT_VERBOSE_LOGS={{getenv "VPN_VERBOSE_LOGS" "true"}}
 
 # seconds to wait between receiving SIGTERM and SIGKILL
 DEFAULT_SIGTERM_TIMEOUT={{getenv "DEFAULT_SIGTERM_TIMEOUT" "120"}}
+MINIMUM_DRAIN_RATE={{getenv "MINIMUM_DRAIN_RATE"}}
 
 VPN_HAPROXY_SOCKET={{getenv "VPN_HAPROXY_SOCKET" "/run/haproxy.sock"}}
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -65,6 +65,10 @@ export const VPN_API_PORT = intVar('VPN_API_PORT');
 // milliseconds
 export const DEFAULT_SIGTERM_TIMEOUT =
 	intVar('DEFAULT_SIGTERM_TIMEOUT') * SECONDS;
+// We convert the drain rate per minute to the equivalent max delay for ease of use elsewhere
+export const MAXIMUM_DRAIN_DELAY = Math.round(
+	(1 * MINUTES) / intVar('MINIMUM_DRAIN_RATE_PER_MINUTE', 500),
+);
 
 export const VPN_INSTANCE_COUNT = getInstanceCount('VPN_INSTANCE_COUNT');
 export const VPN_VERBOSE_LOGS = boolVar('DEFAULT_VERBOSE_LOGS');


### PR DESCRIPTION
This avoids unnecessarily waiting for the full duration of the grace period if there are only a few clients connected

Change-type: minor

<!-- You can remove tags that do not apply. -->
Change-type: major|minor|patch <!-- The change type of this PR -->
Connects-to: # <!-- waffle convention to track a PR's status through its connected, open issue -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Build output has been rebuilt and tested
- [ ] Introduces security considerations
- [ ] Tests are included
- [ ] Documentation is added or changed
- [ ] Affects the development, build or deployment processes of the component

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
