### PR TITLE
capture stderr logs from client connect/disconnect script

### DIFF
--- a/openvpn/scripts/client-connect-disconnect.sh
+++ b/openvpn/scripts/client-connect-disconnect.sh
@@ -17,7 +17,7 @@
 
 function cleanup() {
 	if [[ $? -gt 0 ]]; then
- 		cat </tmp/$PPID.tmp >/tmp/stderr-$PPID.log  		
+ 		cat </tmp/$PPID.tmp >>/tmp/stderr-$PPID.log  		
 	fi
 	rm /tmp/$PPID.tmp
 }

--- a/openvpn/scripts/client-connect-disconnect.sh
+++ b/openvpn/scripts/client-connect-disconnect.sh
@@ -15,17 +15,25 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+function cleanup() {
+	if [[ $? -gt 0 ]]; then
+ 		cat </tmp/$PPID.tmp >/tmp/stderr-$PPID.log  		
+	fi
+	rm /tmp/$PPID.tmp
+}
+trap 'cleanup' EXIT
+
 VPN_INSTANCE_ID=$1
 VPN_API_PORT=$2
 
 if [[ -z "${bytes_received}" ]]; then
-	curl -s -X POST -H 'Content-type: application/json' -d @- "http://127.0.0.1:${VPN_API_PORT}/api/v2/${VPN_INSTANCE_ID}/clients" >/dev/null <<-EOF &
+	curl -s -X POST -H 'Content-type: application/json' -d @- "http://127.0.0.1:${VPN_API_PORT}/api/v2/${VPN_INSTANCE_ID}/clients" 2>/tmp/$PPID.tmp <<-EOF &
 {
 	"common_name": "$common_name"
 }
 EOF
 else
-	curl -s -X DELETE -H 'Content-type: application/json' -d @- "http://127.0.0.1:${VPN_API_PORT}/api/v2/${VPN_INSTANCE_ID}/clients" >/dev/null <<-EOF &
+	curl -s -X DELETE -H 'Content-type: application/json' -d @- "http://127.0.0.1:${VPN_API_PORT}/api/v2/${VPN_INSTANCE_ID}/clients" 2>/tmp/$PPID.tmp <<-EOF &
 {
 	"common_name": "$common_name",
 	"bytes_received": $bytes_received,


### PR DESCRIPTION
* this script signals the API that a client has connected (or disconnected) and it is important to understand if any of these events are failing to reach open-balena-vpn API as they can lead to balena-api being unaware of client VPN state change

change-type: patch
