### PR TITLE
Revert the openvpn server status file to version 1 format.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -118,5 +118,4 @@ COPY config/services /etc/systemd/system
 RUN systemctl enable \
 	open-balena-vpn.service \
 	node-exporter.service \
-	process-exporter.service \
-	openvpn-exporter.service
+	process-exporter.service

--- a/src/utils/openvpn.ts
+++ b/src/utils/openvpn.ts
@@ -158,7 +158,7 @@ export class VpnManager extends EventEmitter implements VpnManagerEvents {
 		const gateway = this.gateway ?? this.subnet.first;
 		return [
 			'--status-version',
-			'2',
+			'1',
 			'--writepid',
 			this.pidFile,
 			'--status',


### PR DESCRIPTION
libnss-openvpn is unable to read OpenVPN server status file version 2 thus breaking the name resolution.  This commit reverts the status file format to the previous version (1) and disables the openvpn-exporter which relies on the version 2 status file format.

Project: https://balena.fibery.io/Work/Project/OpenVPN-prometheus-exporter-1003

Change-type: patch
