### PR TITLE
Avoid redundant `eq true` when checking `is_connected_to_vpn` boolean

### DIFF
--- a/src/utils/device.ts
+++ b/src/utils/device.ts
@@ -111,7 +111,7 @@ export const getDeviceVpnHost = async (
 					manages__device: {
 						$any: {
 							$alias: 'd',
-							$expr: { d: { uuid, is_connected_to_vpn: true } },
+							$expr: { d: { uuid, $: 'is_connected_to_vpn' } },
 						},
 					},
 				},

--- a/test/app.ts
+++ b/test/app.ts
@@ -226,7 +226,7 @@ describe('VPN proxy', function () {
 						d: [
 							{
 								id: 1,
-								is_connected_to_vpn: 1,
+								is_connected_to_vpn: true,
 							},
 						],
 					}),
@@ -292,7 +292,7 @@ describe('VPN proxy', function () {
 						d: [
 							{
 								id: 2,
-								is_connected_to_vpn: 1,
+								is_connected_to_vpn: true,
 							},
 						],
 					}),
@@ -317,7 +317,7 @@ describe('VPN proxy', function () {
 		it('should refuse to forward via itself', async () => {
 			nock(BALENA_API_INTERNAL_HOST)
 				.get(
-					'/v7/service_instance?$select=id,ip_address&$filter=manages__device/any(d:(d/uuid%20eq%20%27c0ffeec0ffeec0ffee%27)%20and%20(d/is_connected_to_vpn%20eq%20true))',
+					'/v7/service_instance?$select=id,ip_address&$filter=manages__device/any(d:(d/uuid%20eq%20%27c0ffeec0ffeec0ffee%27)%20and%20d/is_connected_to_vpn)',
 				)
 				.reply(
 					200,
@@ -342,7 +342,7 @@ describe('VPN proxy', function () {
 		it('should detect forward loops', async () => {
 			nock(BALENA_API_INTERNAL_HOST)
 				.get(
-					'/v7/service_instance?$select=id,ip_address&$filter=manages__device/any(d:(d/uuid%20eq%20%27c0ffeec0ffeec0ffee%27)%20and%20(d/is_connected_to_vpn%20eq%20true))',
+					'/v7/service_instance?$select=id,ip_address&$filter=manages__device/any(d:(d/uuid%20eq%20%27c0ffeec0ffeec0ffee%27)%20and%20d/is_connected_to_vpn)',
 				)
 				.reply(
 					200,
@@ -385,7 +385,7 @@ describe('VPN proxy', function () {
 						d: [
 							{
 								id: 3,
-								is_connected_to_vpn: 1,
+								is_connected_to_vpn: true,
 							},
 						],
 					}),


### PR DESCRIPTION
<!-- You can remove tags that do not apply. -->
Change-type: major|minor|patch <!-- The change type of this PR -->
Connects-to: # <!-- waffle convention to track a PR's status through its connected, open issue -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Build output has been rebuilt and tested
- [ ] Introduces security considerations
- [ ] Tests are included
- [ ] Documentation is added or changed
- [ ] Affects the development, build or deployment processes of the component

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
