### PR TITLE
Fix s6 command to check service status

### DIFF
--- a/docker-hc
+++ b/docker-hc
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 set -ex
 
+# https://skarnet.org/software/s6/s6-svstat.html
 is_up() {
 	local service="$1"
 	local result
-	result="$(s6-svstat "/run/service/${service}" -o up)"
+	result="$(s6-svstat -u "/run/service/${service}")"
 	test "${result}" = "true"
 }
 


### PR DESCRIPTION
Arguement order matters, and -u (or -o up) needs
to proceed the service path.

See https://skarnet.org/software/s6/s6-svstat.html

Change-type: patch
See: https://balena.fibery.io/Work/Project/Make-Cloudlink-deployable-again-1909

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Build output has been rebuilt and tested
- [ ] Introduces security considerations
- [ ] Tests are included
- [ ] Documentation is added or changed
- [ ] Affects the development, build or deployment processes of the component

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
