### PR TITLE
getDeviceVpnHost: Make the raw is_connected_to_vpn filter more explicit using the alias

### DIFF
--- a/src/utils/device.ts
+++ b/src/utils/device.ts
@@ -113,7 +113,7 @@ export const getDeviceVpnHost = async (
 							$alias: 'd',
 							$expr: {
 								d: { uuid },
-								$: 'is_connected_to_vpn',
+								$: ['d', 'is_connected_to_vpn'],
 							},
 						},
 					},

--- a/test/app.ts
+++ b/test/app.ts
@@ -315,7 +315,7 @@ describe('VPN proxy', function () {
 		});
 
 		it('should refuse to forward via itself', async () => {
-			nock(BALENA_API_INTERNAL_HOST)
+			const scope = nock(BALENA_API_INTERNAL_HOST)
 				.get(
 					'/v7/service_instance?$select=id,ip_address&$filter=manages__device/any(d:(d/uuid%20eq%20%27c0ffeec0ffeec0ffee%27)%20and%20d/is_connected_to_vpn)',
 				)
@@ -337,10 +337,11 @@ describe('VPN proxy', function () {
 						}),
 					).to.eventually.be.rejected,
 			);
+			expect(scope.isDone()).to.be.true;
 		});
 
 		it('should detect forward loops', async () => {
-			nock(BALENA_API_INTERNAL_HOST)
+			const scope = nock(BALENA_API_INTERNAL_HOST)
 				.get(
 					'/v7/service_instance?$select=id,ip_address&$filter=manages__device/any(d:(d/uuid%20eq%20%27c0ffeec0ffeec0ffee%27)%20and%20d/is_connected_to_vpn)',
 				)
@@ -367,6 +368,7 @@ describe('VPN proxy', function () {
 						}),
 					).to.eventually.be.rejected,
 			);
+			expect(scope.isDone()).to.be.true;
 		});
 	});
 
@@ -393,7 +395,7 @@ describe('VPN proxy', function () {
 		});
 
 		it('should not allow port 8080 without authentication', async () => {
-			nock(BALENA_API_INTERNAL_HOST)
+			const scope = nock(BALENA_API_INTERNAL_HOST)
 				.post('/v7/device(@id)/canAccess?@id=3', {
 					action: { or: ['tunnel-any', 'tunnel-8080'] },
 				})
@@ -410,10 +412,11 @@ describe('VPN proxy', function () {
 						}),
 					).to.eventually.be.rejected,
 			);
+			expect(scope.isDone()).to.be.true;
 		});
 
 		it('should allow port 8080 with authentication', async () => {
-			nock(BALENA_API_INTERNAL_HOST)
+			const scope = nock(BALENA_API_INTERNAL_HOST)
 				.post('/v7/device(@id)/canAccess?@id=3', {
 					action: { or: ['tunnel-any', 'tunnel-8080'] },
 				})
@@ -438,6 +441,7 @@ describe('VPN proxy', function () {
 				expect(response)
 					.to.have.property('body')
 					.that.equals('hello from 8080');
+				expect(scope.isDone()).to.be.true;
 			});
 		});
 	});


### PR DESCRIPTION
Makes the query a bit more explicit, scoping the is_connected_to_vpn under the alias
before:
```
...$filter=manages__device/any(d:(d/uuid%20eq%20%27<UUID>%27)%20and%20is_connected_to_vpn)
```
after:
```
...$filter=manages__device/any(d:(d/uuid%20eq%20%27<UUID>%27)%20and%20d/is_connected_to_vpn)
```

Change-type: patch
See: https://balena.fibery.io/Security/Information_Security_and_Reliability_Incident/Elevated-Device-VPN-Tunnel-Errors-150

<!-- You can remove tags that do not apply. -->
Change-type: major|minor|patch <!-- The change type of this PR -->
Connects-to: # <!-- waffle convention to track a PR's status through its connected, open issue -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Build output has been rebuilt and tested
- [ ] Introduces security considerations
- [ ] Tests are included
- [ ] Documentation is added or changed
- [ ] Affects the development, build or deployment processes of the component

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
