### PR TITLE
Retry local tunnel connection if the device is linked to this instance

### DIFF
--- a/src/proxy-worker.ts
+++ b/src/proxy-worker.ts
@@ -26,6 +26,7 @@ import {
 	VPN_CONNECT_PROXY_PORT,
 	VPN_FORWARD_PROXY_PORT,
 	VPN_SERVICE_API_KEY,
+	VPN_STATUS_FILE_WRITE_INTERVAL_SECONDS,
 } from './utils/config.js';
 import * as errors from './utils/errors.js';
 import { Metrics } from './utils/metrics.js';
@@ -35,8 +36,18 @@ import {
 	getDeviceVpnHost,
 } from './utils/device.js';
 import { context, propagation, trace } from '@opentelemetry/api';
+import { setTimeout } from 'timers/promises';
 
 const HTTP_500 = 'HTTP/1.0 500 Internal Server Error\r\n\r\n';
+
+const deviceIsLocal = async (uuid: string) => {
+	try {
+		await dns.lookup(`${uuid}.vpn`);
+		return true;
+	} catch {
+		return false;
+	}
+};
 
 class Tunnel extends nodeTunnel.Tunnel {
 	private readonly logger: winston.Logger;
@@ -79,6 +90,25 @@ class Tunnel extends nodeTunnel.Tunnel {
 		});
 	}
 
+	private async localConnect(
+		port: number,
+		host: string,
+		client: net.Socket,
+		req: nodeTunnel.Request,
+	) {
+		this.logger.info(`connecting to ${host}:${port}`);
+		const socket = await super.connect(port, host, client, req);
+		metrics.inc(Metrics.ActiveTunnels);
+		metrics.inc(Metrics.TotalTunnels);
+		socket.on('close', (hadError) => {
+			metrics.dec(Metrics.ActiveTunnels);
+			if (hadError) {
+				metrics.inc(Metrics.TunnelErrors);
+			}
+		});
+		return socket;
+	}
+
 	public connect = async (
 		port: number,
 		host: string,
@@ -87,28 +117,9 @@ class Tunnel extends nodeTunnel.Tunnel {
 	) => {
 		const { uuid, auth } = this.parseRequest(req);
 
-		const deviceIsLocal = async () => {
-			try {
-				await dns.lookup(`${uuid}.vpn`);
-				return true;
-			} catch {
-				return false;
-			}
-		};
-
 		try {
-			if (await deviceIsLocal()) {
-				this.logger.info(`connecting to ${host}:${port}`);
-				const socket = await super.connect(port, host, client, req);
-				metrics.inc(Metrics.ActiveTunnels);
-				metrics.inc(Metrics.TotalTunnels);
-				socket.on('close', (hadError) => {
-					metrics.dec(Metrics.ActiveTunnels);
-					if (hadError) {
-						metrics.inc(Metrics.TunnelErrors);
-					}
-				});
-				return socket;
+			if (await deviceIsLocal(uuid)) {
+				return await this.localConnect(port, host, client, req);
 			} else {
 				const vpnHost = await getDeviceVpnHost(uuid, auth);
 				if (vpnHost == null) {
@@ -118,6 +129,12 @@ class Tunnel extends nodeTunnel.Tunnel {
 					);
 				}
 				if (vpnHost.id === this.serviceId) {
+					// Add a delay matching the interval for writing the VPN status file to allow time for the status file to be updated
+					// in case the previous failure to find locally was due to a race condition where the status file had not yet been updated
+					await setTimeout(VPN_STATUS_FILE_WRITE_INTERVAL_SECONDS * 1000);
+					if (await deviceIsLocal(uuid)) {
+						return await this.localConnect(port, host, client, req);
+					}
 					client.end(HTTP_500);
 					throw new errors.HandledTunnelingError(
 						'device is not available on registered service instance',


### PR DESCRIPTION
This helps with a potential race condition where the local dns lookup fails for a device that has just connected and been marked as so in the API but the status file has not yet been written and hence the dns cannot resolve the device uuid yet

Change-type: patch

<!-- You can remove tags that do not apply. -->
Change-type: major|minor|patch <!-- The change type of this PR -->
Connects-to: # <!-- waffle convention to track a PR's status through its connected, open issue -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Build output has been rebuilt and tested
- [ ] Introduces security considerations
- [ ] Tests are included
- [ ] Documentation is added or changed
- [ ] Affects the development, build or deployment processes of the component

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
