### PR TITLE
Define session_duration in the primary instead of workers

### DIFF
--- a/src/utils/metrics.ts
+++ b/src/utils/metrics.ts
@@ -37,19 +37,6 @@ export const describeWorkerMetrics = () => {
 		'total tx bytes across all vpn sessions',
 	);
 	metrics.counter(Metrics.TxBytes, 0);
-	const min = 60;
-	const hour = 60 * min;
-	const day = 24 * hour;
-	const week = 7 * day;
-	const month = 4 * week;
-	const durationBuckets = [1, 10, min, hour, day, week, month];
-	metrics.describe.histogram(
-		Metrics.SessionDuration,
-		'histogram showing duration of vpn sessions',
-		{
-			buckets: durationBuckets,
-		},
-	);
 	metrics.describe.gauge(
 		Metrics.ActiveTunnels,
 		'current tunnels to vpn devices',
@@ -111,5 +98,27 @@ export const describePrimaryMetrics = () => {
 		Metrics.SessionTxBitrate,
 		'histogram of average tx rate per vpn client',
 		{ buckets: bitrateBuckets },
+	);
+	const min = 60;
+	const hour = 60 * min;
+	const day = 24 * hour;
+	const week = 7 * day;
+	const durationBuckets = [
+		1 * min,
+		5 * min,
+		15 * min,
+		1 * hour,
+		6 * hour,
+		12 * hour,
+		1 * day,
+		1 * week, // 1w  - very stable long-running sessions, could be affected by deployment restarts, but still worth tracking
+	];
+
+	metrics.describe.histogram(
+		Metrics.SessionDuration,
+		'histogram showing duration of vpn sessions',
+		{
+			buckets: durationBuckets,
+		},
 	);
 };


### PR DESCRIPTION
The vpn_session_duration histogram was using default Prometheus
buckets instead of the configured duration buckets - because
this was in the worker configuration/definition instead of
the primary where it is called. Also, update bucket boundaries
to meaningful durations for VPN sessions.

Change-type: patch
FIbery: https://balena.fibery.io/Work/Project/Data-Infrastructure-for-Usable-Time-Series-of-Online-Devices-1879