### PR TITLE
Fix test-compose TUN device setup for Podman on macOS

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -6,6 +6,8 @@ services:
     cap_add:
       - NET_ADMIN
       - SYS_RESOURCE # Required for haproxy's config setting 'ulimit-n 1048576'
+    devices:
+      - /dev/net/tun:/dev/net/tun
     volumes:
       - ./src:/usr/src/app/src:ro
       - ./test:/usr/src/app/test:ro
@@ -52,7 +54,7 @@ services:
 
         mkdir -p /dev/net /run/openvpn /run/openvpn-client /run/openvpn-server
 
-        if [ ! -c /dev/net/tun ]; then
+        if [ ! -e /dev/net/tun ]; then
           mknod /dev/net/tun c 10 200
         fi
 


### PR DESCRIPTION
- Map /dev/net/tun from the host (Podman VM) into the container via the `devices` key so mknod is skipped when the device already exists.
- Change the guard from `[ ! -c ... ]` (is a character device) to `[ ! -e ... ]` (exists at all) to handle Podman on macOS, where the mapped device may not be recognised as a char-device type by the shell test even though it is present.

Requires the Podman Machine to be running in rootful mode:
  podman machine stop
  podman machine set --rootful
  podman machine start