### PR TITLE
Add 'X64' label to linux/amd64 docker runs

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -27,6 +27,6 @@ jobs:
       docker_images: balena/open-balena-vpn
       docker_runs_on: >
         {
-          "linux/amd64": ["self-hosted"],
+          "linux/amd64": ["self-hosted","X64"],
           "linux/arm64": ["self-hosted","ARM64"]
         }


### PR DESCRIPTION
This ensures we only test on the target architecture.

Change-type: patch
See: https://balena.zulipchat.com/#narrow/channel/348930-balena-io.2Fflowzone/topic/Wrong.20github.20runner.20architecture.20selected/near/601904404
See: https://balena.fibery.io/Work/Improvement/Ensure-that-self-hosted-Docker-jobs-are-using-the-target-architecture-4370

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Build output has been rebuilt and tested
- [ ] Introduces security considerations
- [ ] Tests are included
- [ ] Documentation is added or changed
- [ ] Affects the development, build or deployment processes of the component

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
