### PR TITLE
Treat 503 as an expected authentication response

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -47,23 +47,46 @@ const fromLocalHost: express.RequestHandler = (req, res, next) => {
 	next();
 };
 
-const checkDeviceAuth = memoize(
-	async (username: string, password: string) => {
-		const { statusCode } = await pooledRequest.get({
-			url: `${BALENA_API_INTERNAL_HOST}/services/vpn/auth/${username}`,
-			...getPassthrough(`Bearer ${password}`),
-		});
-		if ([200, 401, 403].includes(statusCode)) {
-			return statusCode;
+const checkDeviceAuth = (() => {
+	class ExpectedAuthError extends Error {
+		constructor(public statusCode: number) {
+			super();
 		}
-		throw new Error(`Unexpected status code from the API: ${statusCode}`);
-	},
-	{
-		maxAge: VPN_AUTH_CACHE_TIMEOUT,
-		primitive: true,
-		promise: true,
-	},
-);
+	}
+	const $checkDeviceAuth = memoize(
+		async (username: string, password: string) => {
+			const { statusCode } = await pooledRequest.get({
+				url: `${BALENA_API_INTERNAL_HOST}/services/vpn/auth/${username}`,
+				...getPassthrough(`Bearer ${password}`),
+			});
+			if ([200, 401, 403].includes(statusCode)) {
+				return statusCode;
+			}
+			if (statusCode === 503) {
+				// 503 is an expected error code but we don't want to cache it, so we throw a special error that will not be cached
+				// but will be caught and and have the actual status code returned to the client so it can do normal failure handling
+				// (eg delaying to reduce load).
+				throw new ExpectedAuthError(statusCode);
+			}
+			throw new Error(`Unexpected status code from the API: ${statusCode}`);
+		},
+		{
+			maxAge: VPN_AUTH_CACHE_TIMEOUT,
+			primitive: true,
+			promise: true,
+		},
+	);
+	return async (username: string, password: string) => {
+		try {
+			return await $checkDeviceAuth(username, password);
+		} catch (err) {
+			if (err instanceof ExpectedAuthError) {
+				return err.statusCode;
+			}
+			throw err;
+		}
+	};
+})();
 
 export const apiFactory = (serviceId: number) => {
 	const api = express.Router();


### PR DESCRIPTION
This avoids spamming error reports on a 503 and instead uses the auth failure delay mechanism which will reduce the load we create on the API and also on openvpn from reconnect attempts and help reduce subsequent 503s and other slowness

Change-type: patch

<!-- You can remove tags that do not apply. -->
Change-type: major|minor|patch <!-- The change type of this PR -->
Connects-to: # <!-- waffle convention to track a PR's status through its connected, open issue -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Build output has been rebuilt and tested
- [ ] Introduces security considerations
- [ ] Tests are included
- [ ] Documentation is added or changed
- [ ] Affects the development, build or deployment processes of the component

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
