### PR TITLE
Treat a 401 on `getDeviceVpnHost` as a signal to retry locally

### DIFF
--- a/src/proxy-worker.ts
+++ b/src/proxy-worker.ts
@@ -128,9 +128,12 @@ class Tunnel extends nodeTunnel.Tunnel {
 						'service instance not found for device',
 					);
 				}
-				if (vpnHost.id === this.serviceId) {
-					// Add a delay matching the interval for writing the VPN status file to allow time for the status file to be updated
-					// in case the previous failure to find locally was due to a race condition where the status file had not yet been updated
+				if (vpnHost === false || vpnHost.id === this.serviceId) {
+					// If we could not look up the alternate VPN host, or if the looked up VPN host is the same as the current then we should
+					// retry after a delay to allow time for the status file to be updated, handling the case that the previous failure to find
+					// the device locally was due to a race condition where the status file had not yet been updated. We match the delay to the
+					// interval for writing the VPN status file to ensure it definitely has enough time to be updated, however it would be possible
+					// to use a shorter delay/more retries to improve responsiveness.
 					await setTimeout(VPN_STATUS_FILE_WRITE_INTERVAL_SECONDS * 1000);
 					if (await deviceIsLocal(uuid)) {
 						return await this.localConnect(port, host, client, req);

--- a/src/utils/device.ts
+++ b/src/utils/device.ts
@@ -96,7 +96,7 @@ interface VpnHost {
 export const getDeviceVpnHost = async (
 	uuid: string,
 	auth?: Buffer,
-): Promise<VpnHost | undefined> => {
+): Promise<VpnHost | undefined | false> => {
 	try {
 		const services = await balenaApi.get({
 			resource: 'service_instance',
@@ -118,7 +118,13 @@ export const getDeviceVpnHost = async (
 		});
 		return services[0];
 	} catch (err) {
-		if (!(err instanceof StatusError) || err.statusCode !== 401) {
+		if (err instanceof StatusError && err.statusCode === 401) {
+			// If we got a 401 it means we can not look up an alternate VPN host, so we return false
+			// to signify that and allow retrying on this device with the expectation that the request
+			// had to explicitly target the correct instance already.
+			return false;
+		}
+		if (!(err instanceof StatusError)) {
 			// Do not capture `Unauthorized` errors
 			captureException(err, 'device-vpn-host-lookup-error');
 		}


### PR DESCRIPTION
If the authentication details are allowed to access the device but not allowed to redirect to another instance then we treat it as that the correct instance must have been targeted in the first place and so can react the same as if the redirect instance would be the current instance. This is most likely to come up in the case of the API making requests where it uses a privileged key to update devices and we would prefer to avoid giving that key the ability to also read every service instance/device

Change-type: patch

<!-- You can remove tags that do not apply. -->
Change-type: major|minor|patch <!-- The change type of this PR -->
Connects-to: # <!-- waffle convention to track a PR's status through its connected, open issue -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Build output has been rebuilt and tested
- [ ] Introduces security considerations
- [ ] Tests are included
- [ ] Documentation is added or changed
- [ ] Affects the development, build or deployment processes of the component

##### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
---
